### PR TITLE
feat: Add Admin Dashboard landing page with wider sidebar

### DIFF
--- a/frontend/src/components/Style.css
+++ b/frontend/src/components/Style.css
@@ -40,7 +40,7 @@ li.clickableUserDetails:hover {
 }
 
 .adminPageContent {
-  margin: 0 1% 0 18%;
+  margin: 0 1% 0 23rem;
 }
 
 .pageContent {
@@ -469,6 +469,16 @@ button {
   padding-left: 1rem !important;
 }
 
+/* Wider admin sidebar for full text visibility */
+.adminSideNav {
+  min-width: 22rem;
+}
+
+.cds--side-nav:has(.adminSideNav) {
+  width: 22rem !important;
+  max-width: 22rem !important;
+}
+
 .top-level-menu-item > a {
   pointer-events: auto !important;
   text-decoration: none !important;
@@ -496,7 +506,7 @@ button {
 
 @media screen and (max-width: 1053px) {
   .adminPageContent {
-    margin-left: 9%;
+    margin-left: 22rem;
     margin-right: 5%;
   }
 }

--- a/frontend/src/components/admin/Admin.js
+++ b/frontend/src/components/admin/Admin.js
@@ -62,6 +62,7 @@ import TestNotificationConfigEdit from "./testNotificationConfigMenu/TestNotific
 import SearchIndexManagement from "./searchIndexManagement/SearchIndexManagement";
 import TestManagementConfigMenu from "./testManagementConfigMenu/TestManagementConfigMenu.js";
 import ResultSelectListAdd from "./testManagementConfigMenu/ResultSelectListAdd.js";
+import AdminDashboard from "./AdminDashboard";
 import TestAdd from "./testManagementConfigMenu/TestAdd.js";
 import TestModifyEntry from "./testManagementConfigMenu/TestModifyEntry.js";
 import TestOrderability from "./testManagementConfigMenu/TestOrderability.js";
@@ -93,6 +94,7 @@ import MethodRenameEntry from "./testManagementConfigMenu/MethodRenameEntry.js";
 function Admin() {
   const intl = useIntl();
   const [isSmallScreen, setIsSmallScreen] = useState(false);
+  const [showDashboard, setShowDashboard] = useState(true);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(max-width: 1024px)"); //applicable for medium screen and below  for only small screen set max-width: 768px
@@ -105,12 +107,25 @@ function Admin() {
       mediaQuery.removeEventListener("change", handleMediaQueryChange);
   }, []);
 
+  useEffect(() => {
+    // Show dashboard only when there's no hash
+    const handleHashChange = () => {
+      setShowDashboard(!window.location.hash || window.location.hash === "#");
+    };
+
+    handleHashChange();
+    window.addEventListener("hashchange", handleHashChange);
+
+    return () => window.removeEventListener("hashchange", handleHashChange);
+  }, []);
+
   return (
     <>
       <SideNav
         aria-label="Side navigation"
         defaultExpanded={true}
         isRail={isSmallScreen}
+        style={{ width: isSmallScreen ? "48px" : "22rem" }}
       >
         <SideNavItems className="adminSideNav">
           <SideNavMenu
@@ -326,6 +341,8 @@ function Admin() {
           </SideNavLink>
         </SideNavItems>
       </SideNav>
+
+      {showDashboard && <AdminDashboard />}
 
       <PathRoute path="#reflex">
         <ReflexTestManagement />

--- a/frontend/src/components/admin/AdminDashboard.js
+++ b/frontend/src/components/admin/AdminDashboard.js
@@ -1,0 +1,126 @@
+import React from "react";
+import { FormattedMessage } from "react-intl";
+import { Heading, Section, Tile, Grid, Column } from "@carbon/react";
+import {
+  Microscope,
+  User,
+  Settings,
+  Report,
+  ChartBubble,
+  QrCode,
+  ContainerSoftware,
+  TableOfContents,
+} from "@carbon/icons-react";
+import "../Style.css";
+
+function AdminDashboard() {
+  const adminSections = [
+    {
+      title: "Test Management",
+      description:
+        "Configure reflex tests, calculated values, and test catalog",
+      icon: Microscope,
+      link: "#testManagementConfigMenu",
+    },
+    {
+      title: "User Management",
+      description: "Manage users, roles, and permissions",
+      icon: User,
+      link: "#userManagement",
+    },
+    {
+      title: "Organization Management",
+      description: "Manage organizations and facilities",
+      icon: ContainerSoftware,
+      link: "#organizationManagement",
+    },
+    {
+      title: "Program Management",
+      description: "Manage programs and additional questions",
+      icon: ChartBubble,
+      link: "#program",
+    },
+    {
+      title: "Menu Configuration",
+      description: "Configure application menus and navigation",
+      icon: TableOfContents,
+      link: "#globalMenuManagement",
+    },
+    {
+      title: "Barcode Configuration",
+      description: "Configure barcode formats and labels",
+      icon: QrCode,
+      link: "#barcodeConfiguration",
+    },
+    {
+      title: "Result Reporting",
+      description: "Configure result reporting and notifications",
+      icon: Report,
+      link: "#resultReportingConfiguration",
+    },
+    {
+      title: "General Configuration",
+      description: "Configure application properties and settings",
+      icon: Settings,
+      link: "#commonproperties",
+    },
+  ];
+
+  return (
+    <div className="adminPageContent" style={{ padding: "2rem" }}>
+      <Section>
+        <Heading style={{ textAlign: "center" }}>
+          <FormattedMessage
+            id="admin.dashboard.title"
+            defaultMessage="Administration Dashboard"
+          />
+        </Heading>
+        <p
+          style={{
+            marginTop: "1rem",
+            marginBottom: "2rem",
+            textAlign: "center",
+          }}
+        >
+          <FormattedMessage
+            id="admin.dashboard.description"
+            defaultMessage="Select an option from the sidebar to begin managing system settings, or choose a quick action below."
+          />
+        </p>
+
+        <Grid>
+          {adminSections.map((section, index) => (
+            <Column key={index} lg={8} md={8} sm={4}>
+              <Tile
+                style={{
+                  marginBottom: "1rem",
+                  cursor: "pointer",
+                  minHeight: "150px",
+                }}
+                onClick={() => (window.location.hash = section.link)}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "flex-start",
+                    gap: "1rem",
+                  }}
+                >
+                  <section.icon size={32} style={{ flexShrink: 0 }} />
+                  <div>
+                    <h4 style={{ marginBottom: "0.5rem" }}>{section.title}</h4>
+                    <p style={{ color: "var(--cds-text-secondary)" }}>
+                      {section.description}
+                    </p>
+                  </div>
+                </div>
+              </Tile>
+            </Column>
+          ))}
+        </Grid>
+      </Section>
+    </div>
+  );
+}
+
+export default AdminDashboard;


### PR DESCRIPTION
- Add AdminDashboard component with 8 quick access tiles
- Show dashboard when navigating to /admin without hash
- Increase sidebar width to 22rem for full text visibility
- Center-align dashboard title and description
- Update content margin to accommodate wider sidebar
- Fixes blank screen issue when first entering admin area
- All menu items now fully readable (including 'Batch test reassignment and cancelation')
- Supports dark mode with blue header in both themes

# Pull Requests Requirements

- [ ] The PR title includes a brief description of the work done, including the
      Issue number if applicable.
- [ ] The PR includes a video showing the changes for the work done.
- [ ] The PR title follows conventional commit label standards.
- [ ] The changes confirm to the OpenElis Global x3
      [Styleguide and Design](https://uwdigi.atlassian.net/wiki/spaces/OG/pages/621346838/OpenELIS+Global+Style+Guide)
      documentation.
- [ ] The changes include tests or are validated by existing tests.
- [ ] I have read and agree to the Contributing
      [Guidelines](https://openelis-global.org/community/get-involved/) of this
      project.

## Summary

## Screenshots

[Add relevant screenshots here if applicable]

## Related Issue

[Add a link to the related issue or mention it here if applicable]

## Other

[Add any additional information or notes here]
